### PR TITLE
Add a way to disable the curl timeout feature

### DIFF
--- a/doc/vim-rest-console.txt
+++ b/doc/vim-rest-console.txt
@@ -726,7 +726,7 @@ pane. It's disabled by default. To enable:
 ------------------------------------------------------------------------------
 *vrc_show_command_in_quickfix*
 
-This option disables the printing of the executed curl command in the quickfix 
+This option disables the printing of the executed curl command in the quickfix
 list. It's enabled by default. To disable:
 >
     let g:vrc_show_command_in_quickfix = 0
@@ -738,6 +738,11 @@ Kill curl after this timeout - default 1m.
 See man timeout for details.
 >
     let g:vrc_curl_timeout = '5s'
+
+This option cannot be used on Windows because TIMEOUT.EXE serves a different
+purpose than bash's timeout. To disable:
+>
+    let g:vrc_curl_timeout = '0'
 
 ------------------------------------------------------------------------------
 *vrc_show_command_in_result_buffer*
@@ -841,6 +846,7 @@ Thanks to the contributors (in alphabetical order of GitHub account)
     @nathanaelkane
     @nilsboy
     @p1otr
+    @PhilRunninger
     @rawaludin
     @rlisowski
     @sethtrain

--- a/ftplugin/rest.vim
+++ b/ftplugin/rest.vim
@@ -190,7 +190,7 @@ endfunction
 "
 " @param  int  a:start
 " @param  int  a:end
-" @return string 
+" @return string
 "
 function! s:ParsePipe(start, end)
   let pipe = ''
@@ -531,9 +531,17 @@ function! s:GetCurlCommand(request)
   if !empty(a:request.dataBody)
     call add(curlArgs, s:GetCurlDataArgs(a:request))
   endif
+
+  """ Set the curl timeout, removing it if 0 was specified.
   let vrcCurlTimeout = s:GetOpt('vrc_curl_timeout', '1m')
+  if vrcCurlTimeout =~? '^0[smhd]\?$'
+    let vrcCurlTimeout = ''
+  else
+    let vrcCurlTimeout = 'timeout ' . vrcCurlTimeout . ' '
+  endif
+
   return [
-    \ 'timeout ' . vrcCurlTimeout . ' curl --silent ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
+    \ vrcCurlTimeout . 'curl --silent ' . join(curlArgs) . ' ' . s:Shellescape(a:request.host . a:request.requestPath),
     \ curlOpts
   \]
 endfunction
@@ -750,7 +758,7 @@ function! s:DisplayOutput(tmpBufName, outputInfo, config)
   """ Display commands in result buffer if any.
   if s:GetOpt('vrc_show_command_in_result_buffer', 0)
     if (!empty(a:outputInfo['commands']))
-      let prefixedList = map(copy(a:outputInfo['commands']), '"REQUEST: " . v:val . "\t"') 
+      let prefixedList = map(copy(a:outputInfo['commands']), '"REQUEST: " . v:val . "\t"')
       call append(0, prefixedList)
       call append(1, '')
     endif


### PR DESCRIPTION
The `g:vrc_curl_timeout` setting introduced in 308b197d9e5ae97b8c612512faa373d27207e7e8 causes an error when running on Windows. The command being sent to `system()` is:
```
timeout 1m curl --silent -H "content-type: application/json"....
```
and the output window shows this text:
```
ERROR: Invalid syntax. Default option is not allowed more than '1' time(s).
Type "TIMEOUT /?" for usage.
```
The reason this happens is: Windows' `TIMEOUT.EXE` has a different syntax, and more importantly, a different purpose than the `timeout` command in bash.

This pull request introduces a way to remove the `timeout 1m` portion of the command line. It does this with the statement:
```vim
let g:vrc_curl_timeout = '0'    " 0s, 0m, 0h, and 0d also work.
```
This approach was taken over checking `has('win32')`. In Git Bash `has('win32')` returns true, but it **does** have a `timeout` program that works as intended by the aforementioned commit. I can't check WSL, but I suspect it behaves similarly.